### PR TITLE
Update fta_os_init.sh

### DIFF
--- a/fta_os_init.sh
+++ b/fta_os_init.sh
@@ -115,6 +115,7 @@ echo 'net.core.rmem_default=262144' |  tee -a /etc/sysctl.conf
 echo 'net.core.wmem_default=262144' |  tee -a /etc/sysctl.conf
 echo 'net.core.rmem_max=16777216' |  tee -a /etc/sysctl.conf
 echo 'net.core.wmem_max=16777216' |  tee -a /etc/sysctl.conf
+echo 'vm.overcommit_memory=1' |  tee -a /etc/sysctl.conf
 sysctl -p
 
 echo 'performing full system update...'


### PR DESCRIPTION
Redis 警告说，如果内存过度提交未启用，在低内存条件下，后台保存或复制可能会失败。